### PR TITLE
PTP Offload capability Support completion

### DIFF
--- a/idpf_specification.md
+++ b/idpf_specification.md
@@ -6433,28 +6433,101 @@ VIRTCHNL2_OP_RDMA			= 529,
 This OP/call is used as an opaque RDMA virtchannel message between the vendor driver and the Device Control plane. A message buffer from RDMA driver is sent to the Device Control with this Opcode and the Device Control can do the reverse using the same opcode to send a message buffer to the RDMA driver. The interpretation of this message buffer is agreed upon between the Vendor RDMA driver and the Device Control plane.
 
 
+## PTP
+
+### Device Interface
+  
+  Device provides an Interface for synchronizing the system clock with device clock. The interface is mainly to read the device clock. There is no additional interface for software to control or write to the device clock. Device clock sync with external/GrandMaster is taken care of by the device itself. VFs will not have the access to device clock. If a VF is attached to VM, VM will rely on Hypervisor/Qemu API to sync VMs system clock with Host system clock.
+
+### Capability and Data structures
+  
+ This capability consists of multiple sub capabilities that can be exposed by a device and are divided primarily in a few categories as described below. The primary PTP capability request is made by IDPF driver through get_capabilities virtchannel command by setting VIRTCHNL2_CAP_PTP bit in the capability bitmap. If the device supports PTP capability the response from Device Control still has the VIRTCHNL2_CAP_PTP bit set in the capability bitmap.
+
+#### PTP Sub capabilities
+1.	Ability to synchronize system (OS) time with Device time by doing cross time stamping. 
+a.	In legacy devices with no PCIE PTM capability this was done by independently sampling device time and system time but doing it in fashion that they can be done as close in time as possible or by taking two system time sample one before taking the device time sample and one immediately after the device time sample and the mean system time value between the two would be approximately the same time when the device time was sampled.
+This capability is exposed as 
+VIRTCHNL2_PTP_CAP_GET_DEVICE_CLK_TIME
+VIRTCHNL2_PTP_CAP_GET_DEVICE_CLK_TIME_MB
+Note: The Mailbox (_MB) version to get Device time over mailbox is generally not in use but is for completeness as the Device time over mailbox cannot be relied as being done exactly in the middle of the two system time samples or due to proxy nature can be far off from the system time sample. The capability returns only one time value from the Device, that of the Device master time.
+b.	With PCIE PTM capability, the system OS time and the Device time can be latched simultaneously by the device. This is done by the Device’s ability to sample the system ART timer at the same time the device master timer is sampled. 
+This capability is exposed as
+VIRTCHNL2_PTP_CAP_GET_CROSS_TIME	
+VIRTCHNL2_PTP_CAP_GET_CROSS_TIME_MB 
+Either capability is as accurate as the other in sampling the system and device time as the Mailbox (_MB) mechanism also relies on the Device control plane to be able to latch both system time and the Device at the same instance. The mailbox method just allows for indirect access to reading the latched values by the device. This capability returns two time values one for the Device and one for the system (CPU complex)
+2.	Ability to do Tx time stamping of packets as they leave the Device (typically in the PHY).
+a.	This capability can be used by either the follower (slave)clock server or by the leader (master) clock server in the common PTP network domain to calculate packet delay in transmission and reception between follower and the leader. 
+VIRTCHNL2_PTP_CAP_TX_TSTAMPS	
+VIRTCHNL2_PTP_CAP_TX_TSTAMPS_MB
+The packet delay calculation on the wire is used to accurately remove the time component that is common in calculation of the skew in clock between the leader and the follower. Tx timestamping should be allowed on all vports that are tied to an external port which means there traffic goes only to a particular external physical port.
+3.	Ability to Adjust Device Master Clock, this capability in a multi-complex system is given to one of the CPU complex that is trusted to make this master clock adjustment.  The Complex that calculates the skew between the leader (master system in the PTP network domain)) and the current Device master clock (slave system in the PTP network domain) runs the PTP protocol and algorithm in SW which requires other capabilities such as TX_TSTAMPS and cross timestamping as well from the Device as described in 1 and 2 above. 
+VIRTCHNL2_PTP_CAP_ADJ_DEVICE_CLK
+	VIRTCHNL2_PTP_CAP_ADJ_DEVICE_CLK_MB
+In a system this can be done through direct register writes or over mailbox. If done over mailbox (_MB), the mailbox latency should be constant and adjusted for when setting the device time to be as close in time to the leader as possible. 
+4.	Ability to initialize the Device Master clock, this is done at the start of the server and is done by a trusted entity for the system. Again this can be done directly or over mailbox (_MB), when doing it over mailbox similar consideration for adjustment in mailbox latency should be made.
+VIRTCHNL2_PTP_CAP_SET_DEVICE_CLK_TIME		
+VIRTCHNL2_PTP_CAP_SET_DEVICE_CLK_TIME_MB
+5.	Ability to do Rx Tiemstamping of packets as they arrive on the device, The Device automatically latches timestamp information on the receive path, and the timestamp is carried through the data pipeline in the device as metadata. Using the default 32 byte descriptors as defined in the spec the driver always gets the rx_timestamp in the descriptor as a 40 bit value spread in 3 fields. The driver can check if the rx_timestamp field is valid or not by lowest bit in ts_ns field in the descriptor being 1 or not.  If the lowest bit is set, then the timestamp value is valid for the default 32 byte descriptor.
+There is no explicit enabling or disabling of this capability.
+Advanced RX descriptors when defined for the device for newer capabilities may override the upper 32 bit rx_timestamp fields with other fields and indicate the same with a new RXDID which will define the new field layout for the flex fields. This would require the driver to use the right descriptor layout and adjust the flow accordingly.
+
+
+### Configuration
+
+PTP Virtchannel Commands
+	VIRTCHNL2_OP_PTP_GET_CAPS		
+	VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP	
+	VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME
+	VIRTCHNL2_OP_PTP_GET_CROSS_TIME	
+	VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME
+	VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE
+	VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME
+	VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS
+
+### Driver Configuration and Runtime flow
+  
+ Depending on the OS callbacks into the driver and the Device capabilities granted to the driver, different PTP flows can be triggered.
+For a Tenant untrusted system such as in case of Bare metal renting or a Tenant VM or even when the Infrastructure Control plane runs on a different embedded complex, then the only capability requested by the OS and granted to the device to driver might be to do cross time stamping. Depending on whether PTM capability is supported on the device through PCIE or not, one of the above 4 capabilities might be used for doing cross time stamping. The legacy way of accessing the Device time over mailbox may not be ideal and is more for completeness. PTM whether done over mailbox or directly is the most ideal/accurate way of doing cross time stamping because the System and device times are latched at the same time.
+Flow here is for first the driver to learn what device capabilities are being granted once the driver has hooks from the OS to provide cross time stamping either the legacy or the PTM way.
+#### Init time flow
+1.	Driver has PTP supported code to access the Device support for PTP.
+2.	Driver at Init sets the PTP_CAPABILITY bit in GET_CAPS opcode over the mailbox.
+3.	The Device Control plane responds if the Device supports PTP capability or not for this instance of the driver.
+4.	The driver then sends a PTP_GET_CAPS opcode over the mailbox to Device Control.
+5.	Device Control responds with a bitmap of PTP sub capabilities granted to the driver instance.
+6.	As part of the response for PTP_GET_CAPS if there are direct accesses available from the PCIe Interface, the driver learns the offsets of these register locations as well from the Device Control plane.
+7.	A driver will do the Initialization of the Device master clock. Depending on the CPU complex trust level this capability may or may not be given to the driver instance by the Device Control.  The opcode used for setting of the Device clock indirectly is VIRTCHNL2_OP_PTP_SET_DEVICE_CLK_TIME
+8.	At this point the driver registers hooks into the stack for PTP runtime callbacks.
+9.	A driver may also request a separate dedicated mailbox for doing the indirect access such as for Tx Timestamping, adjusting the Device master clock etc. The way the Device control indicates to the driver to use a dedicated mailbox or not is again through the PTP capability negotiation data structures containing the flags for driver to do the right setup.
+
+#### Runtime flows
+Runtime flows are triggered by the stack and are dependent on what the system and the CPU Complex is being used for. If a system and the CPU Complex is used for Tenant hosting it may only have the Cross timestamping runtime flow. Whereas if a system and the CPU complex attached to the device is used for Infrastructure SW hosting then it may be used for adjusting the Device master clock directly or indirectly.
+If a system is used for a master Independent clock for the PTP network Domain, then it may have some subset of these runtime flows as desired from a given CPU Complex attached to the device. 
+##### Cross time stamping flow done on all CPU complexes attached to the device.
+1.	If the OS supports hooks for PCIE based PTM capability and a callback is received to do PTM cross time stamping, if the capability was granted to the driver instance, the driver makes a call to either do a direct or mailbox based PTM cross time stamping request to the device. Direct method is preferred over the mailbox method for cross timestamping to avoid unnecessary mailbox chatter. The opcodes used for indirect PTM access is VIRTCHNL2_OP_PTP_GET_CROSS_TIME
+2.	If the capability was not granted the driver will fail the call.
+3.	Legacy method of cross timestamping is pretty much supported in all modern OSes although may not be invoked in case of a VM. VM system time may be synchronized with the Hypervisor or Host OS time through a SW flow. Direct access is the only right method for this, mailbox mechanism is only for completeness. 
+##### Tx Timestamping Flow (given to drivers that are not untrusted(tenant) drivers.)
+a.	In this case if the device control plane grants the direct or indirect access for Tx timestamp, the driver learns about the number of latches and the index of the latches as part of initialization. If the access grated is direct access, the driver also learns about the register offsets of the latches in the PCIE MMIO space.
+b.	When a packet comes down with a PTP time stamping request as part of packet meta data from the stack then the driver must enable the Tx timestamping bits in the Tx descriptor and specify one of the free/unused latch ID to be used for timestamping of this Tx packet by the HW.
+c.	 At some point when the packet completion for both buffer and the Tx descriptor is received, then the driver can go request the Tx timestamp reading directly or indirectly over the mailbox. Note:  Here the packet buffer completion is assumed to happen very close to packet scheduling on the wire by the device with no buffering of the packet after that point in the device. The opcode used for indirect tx timestamping reading is VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP	
+d.	When reading the timestamp over mailbox, occasionally the driver can combine the request to get the device time as well along with the Tx timestamp instead of requesting just the timestamp. This is just an optimization to avoid having two mailbox request and cause jitter.
+e.	The driver can now return the latch ID to the free pool, to be used for another PTP timestamping packet.
+##### Rx Timestamping flow
+	For now every 32 byte default RX descriptor carrying a valid packet whether in Single queue or split queue mode is assumed to carry RX timestamp for when the packet is received in the device (mostly at PHY level). A valid rx timestamp value is indicated by device by setting the lowest bit to 1.
+##### Device Master clock and Frequency Skewing flow
+This flow typically is in conjunction with Tx timestamping flows but from the driver perspective, it’s a callback from the stack that can happen anytime. 
+1.	If the callback to adjust the time or the frequency of the device clock is made from the stack into the driver, the driver checks if it has the capability to do direct or indirect Time or frequency adjustment of the device master clock.
+2.	If it has the capability it uses either the direct registers to make the adjustments or send the request over mailbox using the following opcodes VIRTCHNL2_OP_PTP_ADJ_TIME or VIRTCHNL2_OP_PTP_ADJ_FINE
+3.	If done over the mailbox its best to use a dedicated mailbox for it so as to avoid any jitter introduced through mailbox mechanism due to other config requests queue up on the mailbox.
+4.	Device Control may also have separate thread and a mailbox to handle just the PTP requests to avoid similar jitters on the other side.
+5.	This is a write request and does not require a response from the control plane.
+
 # Additional Offloads and capabilities
 
 These offloads are just like standard offloads but not enabled by the
 drivers by default and the NIC vendors do not provide these offloads as
 a standard capability to a PF or a VF device
-
-## PTP (WIP)
-
-- Device Interface
-  
-  Device provides an Interface for synchronizing the system clock with device clock. The interface is mainly to read the device clock. There is no additional interface for software to control or write to the device clock. Device clock sync with external/GrandMaster is taken care of by the device itself. VFs will not have the access to device clock. If a VF is attached to VM, VM will rely on Hypervisor/Qemu API to sync VMs system clock with Host system clock.
-
-- Capability and Data structures
-  
-  The response from VIRTCHNL2_OP_GET_CAPS rrom CP will have the VIRTCHNL2_CAP_PTP information. Driver will use this info to either register the PTP interfaces to driver ro control the requests from the user/stack.
-
-- Configuration
-
-
-- Driver Configuration and Runtime flow
-  
-  On driver initialization/load if the PTP capability is supported by device, driver will register the PTP object along with two read callbacks. *Gettime64* for reading the device clock and *Getcrosststamp* for PTM(Precision Time Measurement). The device registers to read the device clock are SHTIME, SHTIME_L and SHTIME_H. ART_L and ART_H are used for PTM.
 
 ## OEM Capabilities
 
@@ -6470,7 +6543,7 @@ This spec allows the OEMs to add new OEM specific capabilities and export them t
   
   Driver will use the VIRTCHNL2_OP_GET_OEM_CAPS message to learn about the special capabilities that are available. A suggested OEM capability negotiation struct and details plus examples can be found in the Spec appendix.
 
-  ## Application Targeted Routing (ATR)
+## Application Targeted Routing (ATR)
 
 - Device Interface
 
@@ -8261,8 +8334,16 @@ enum virtchnl2_op {
 	VIRTCHNL2_OP_DEL_QUEUE_GROUPS		= 539,
 	VIRTCHNL2_OP_GET_PORT_STATS		= 540,
 	/* TimeSync opcodes */
-	VIRTCHNL2_OP_GET_PTP_CAPS		= 541,
-	VIRTCHNL2_OP_GET_PTP_TX_TSTAMP_LATCHES	= 542,
+	VIRTCHNL2_OP_PTP_GET_CAPS			= 541,
+	VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP		= 542,
+	VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME		= 543,
+	VIRTCHNL2_OP_PTP_GET_CROSS_TIME			= 544,
+	VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME		= 545,
+	VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE		= 546,
+	VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME		= 547,
+	VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS	= 548,
+	VIRTCHNL2_OP_GET_LAN_MEMORY_REGIONS		= 549,
+
 
 #ifdef NOT_FOR_UPSTREAM
 	VIRTCHNL2_OP_GET_OEM_CAPS		= 4999,
@@ -10084,145 +10165,280 @@ VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_promisc_info);
  * enum virtchnl2_ptp_caps - PTP capabilities
  */
 enum virtchnl2_ptp_caps {
-	VIRTCHNL2_PTP_CAP_LEGACY_CROSS_TIME	= BIT(0),
-	VIRTCHNL2_PTP_CAP_PTM			= BIT(1),
-	VIRTCHNL2_PTP_CAP_DEVICE_CLOCK_CONTROL	= BIT(2),
-	VIRTCHNL2_PTP_CAP_TX_TSTAMPS_DIRECT	= BIT(3),
-	VIRTCHNL2_PTP_CAP_TX_TSTAMPS_VIRTCHNL	= BIT(4),
+	VIRTCHNL2_CAP_PTP_GET_DEVICE_CLK_TIME		= BIT(0),
+	VIRTCHNL2_CAP_PTP_GET_DEVICE_CLK_TIME_MB	= BIT(1),
+	VIRTCHNL2_CAP_PTP_GET_CROSS_TIME		= BIT(2),
+	VIRTCHNL2_CAP_PTP_GET_CROSS_TIME_MB		= BIT(3),
+	VIRTCHNL2_CAP_PTP_SET_DEVICE_CLK_TIME		= BIT(4),
+	VIRTCHNL2_CAP_PTP_SET_DEVICE_CLK_TIME_MB	= BIT(5),
+	VIRTCHNL2_CAP_PTP_ADJ_DEVICE_CLK		= BIT(6),
+	VIRTCHNL2_CAP_PTP_ADJ_DEVICE_CLK_MB		= BIT(7),
+	VIRTCHNL2_CAP_PTP_TX_TSTAMPS			= BIT(8),
+	VIRTCHNL2_CAP_PTP_TX_TSTAMPS_MB			= BIT(9),
 };
 
 /**
- * struct virtchnl2_ptp_legacy_cross_time_reg - Legacy cross time registers
- *						offsets.
+ * struct virtchnl2_ptp_clk_reg_offsets - Offsets of device and PHY clocks
+ *					  registers
+ * @dev_clk_ns_l: Device clock low register offset
+ * @dev_clk_ns_h: Device clock high register offset
+ * @phy_clk_ns_l: PHY clock low register offset
+ * @phy_clk_ns_h: PHY clock high register offset
+ * @cmd_sync_trigger: The command sync trigger register offset
+ * @pad: Padding for future extensions
  */
-struct virtchnl2_ptp_legacy_cross_time_reg {
-	__le32 shadow_time_0;
-	__le32 shadow_time_l;
-	__le32 shadow_time_h;
-	__le32 cmd_sync;
-};
-VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_legacy_cross_time_reg);
-
-/**
- * struct virtchnl2_ptp_ptm_cross_time_reg - PTM cross time registers offsets
- */
-struct virtchnl2_ptp_ptm_cross_time_reg {
-	__le32 art_l;
-	__le32 art_h;
-	__le32 cmd_sync;
+struct virtchnl2_ptp_clk_reg_offsets {
+	__le32 dev_clk_ns_l;
+	__le32 dev_clk_ns_h;
+	__le32 phy_clk_ns_l;
+	__le32 phy_clk_ns_h;
+	__le32 cmd_sync_trigger;
 	u8 pad[4];
 };
-VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_ptm_cross_time_reg);
+
+VIRTCHNL2_CHECK_STRUCT_LEN(24, virtchnl2_ptp_clk_reg_offsets);
 
 /**
- * struct virtchnl2_ptp_device_clock_control - Registers needed to control the
- *					       main clock.
+ * struct virtchnl2_ptp_cross_time_reg_offsets - Offsets of the device cross
+ *						 time registers
+ * @sys_time_ns_l: System time low register offset
+ * @sys_time_ns_h: System time high register offset
+ * @cmd_sync_trigger: The command sync trigger register offset
+ * @pad: Padding for future extensions
  */
-struct virtchnl2_ptp_device_clock_control {
-	__le32 cmd;
-	__le32 incval_l;
-	__le32 incval_h;
-	__le32 shadj_l;
-	__le32 shadj_h;
+struct virtchnl2_ptp_cross_time_reg_offsets {
+	__le32 sys_time_ns_l;
+	__le32 sys_time_ns_h;
+	__le32 cmd_sync_trigger;
 	u8 pad[4];
 };
-VIRTCHNL2_CHECK_STRUCT_LEN(24, virtchnl2_ptp_device_clock_control);
+
+VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_cross_time_reg_offsets);
 
 /**
- * struct virtchnl2_ptp_tx_tstamp_entry - PTP TX timestamp entry
- * @tx_latch_register_base: TX latch register base
- * @tx_latch_register_offset: TX latch register offset
- * @index: Index
- * @pad: Padding
+ * struct virtchnl2_ptp_clk_adj_reg_offsets - Offsets of device and PHY clocks
+ *					      adjustments registers
+ * @dev_clk_cmd_type: Device clock command type register offset
+ * @dev_clk_incval_l: Device clock increment value low register offset
+ * @dev_clk_incval_h: Device clock increment value high registers offset
+ * @dev_clk_shadj_l: Device clock shadow adjust low register offset
+ * @dev_clk_shadj_h: Device clock shadow adjust high register offset
+ * @phy_clk_cmd_type: PHY timer command type register offset
+ * @phy_clk_incval_l: PHY timer increment value low register offset
+ * @phy_clk_incval_h: PHY timer increment value high register offset
+ * @phy_clk_shadj_l: PHY timer shadow adjust low register offset
+ * @phy_clk_shadj_h: PHY timer shadow adjust high register offset
  */
-struct virtchnl2_ptp_tx_tstamp_entry {
-	__le32 tx_latch_register_base;
-	__le32 tx_latch_register_offset;
+struct virtchnl2_ptp_clk_adj_reg_offsets {
+	__le32 dev_clk_cmd_type;
+	__le32 dev_clk_incval_l;
+	__le32 dev_clk_incval_h;
+	__le32 dev_clk_shadj_l;
+	__le32 dev_clk_shadj_h;
+	__le32 phy_clk_cmd_type;
+	__le32 phy_clk_incval_l;
+	__le32 phy_clk_incval_h;
+	__le32 phy_clk_shadj_l;
+	__le32 phy_clk_shadj_h;
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(40, virtchnl2_ptp_clk_adj_reg_offsets);
+
+/**
+ * struct virtchnl2_ptp_tx_tstamp_latch_caps - PTP Tx timestamp latch
+ *					       capabilities
+ * @tx_latch_reg_offset_l: Tx timestamp latch low register offset
+ * @tx_latch_reg_offset_h: Tx timestamp latch high register offset
+ * @index: Latch index provided to the Tx descriptor
+ * @pad: Padding for future extensions
+ */
+struct virtchnl2_ptp_tx_tstamp_latch_caps {
+	__le32 tx_latch_reg_offset_l;
+	__le32 tx_latch_reg_offset_h;
 	u8 index;
 	u8 pad[7];
 };
-VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_tx_tstamp_entry);
+
+VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_tx_tstamp_latch_caps);
 
 /**
- * struct virtchnl2_ptp_tx_tstamp - Structure that defines tx tstamp entries
+ * struct virtchnl2_ptp_get_vport_tx_tstamp_caps - Structure that defines Tx
+ *						   tstamp entries
+ * @vport_id: Vport number
  * @num_latches: Total number of latches
- * @latch_size: Latch size expressed in bits
- * @pad: Padding
- * @ptp_tx_tstamp_entries: Aarray of TX timestamp entries
+ * @tstamp_ns_lo_bit: First bit for nanosecond part of the timestamp
+ * @tstamp_ns_hi_bit: Last bit for nanosecond part of the timestamp
+ * @pad: Padding for future tstamp granularity extensions
+ * @tstamp_latches: Capabilities of Tx timestamp entries
+ *
+ * PF/VF sends this message to negotiate the Tx timestamp latches for each
+ * Vport.
+ *
+ * Associated with VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS
  */
-struct virtchnl2_ptp_tx_tstamp {
+struct virtchnl2_ptp_get_vport_tx_tstamp_caps {
+	__le32 vport_id;
 	__le16 num_latches;
-	__le16 latch_size;
-	u8 pad[4];
-	struct virtchnl2_ptp_tx_tstamp_entry ptp_tx_tstamp_entries[STRUCT_VAR_LEN];
+	u8 tstamp_ns_lo_bit;
+	u8 tstamp_ns_hi_bit;
+	u8 pad[7];
+
+	struct virtchnl2_ptp_tx_tstamp_latch_caps tstamp_latches[STRUCT_VAR_LEN];
 };
-VIRTCHNL2_CHECK_STRUCT_VAR_LEN(24, virtchnl2_ptp_tx_tstamp,
-			       ptp_tx_tstamp_entries);
+
+VIRTCHNL2_CHECK_STRUCT_VAR_LEN(32, virtchnl2_ptp_get_vport_tx_tstamp_caps,
+			       tstamp_latches);
 
 /**
- * struct virtchnl2_get_ptp_caps - Get PTP capabilities
- * @ptp_caps: PTP capability bitmap. See enum virtchnl2_ptp_caps.
- * @pad: Padding
- * @legacy_cross_time_reg: Legacy cross time register
- * @ptm_cross_time_reg: PTM cross time register
- * @device_clock_control: Device clock control
- * @tx_tstamp: TX timestamp
+ * struct virtchnl2_ptp_get_caps - Get PTP capabilities
+ * @caps: PTP capability bitmap. See enum virtchnl2_ptp_caps
+ * @max_adj: The maximum possible frequency adjustment
+ * @base_incval: The default timer increment value
+ * @peer_mbx_q_id: ID of the PTP Device Control daemon queue
+ * @peer_id: Peer ID for PTP Device Control daemon
+ * @secondary_mbx: Indicates to the driver that it should create a secondary
+ *		   mailbox to inetract with control plane for PTP
+ * @pad: Padding for future extensions
+ * @clk_offsets: Main timer and PHY registers offsets
+ * @cross_time_offsets: Cross time registers offsets
+ * @clk_adj_offsets: Offsets needed to adjust the PHY and the main timer
  *
- * PV/VF sends this message to negotiate PTP capabilities. CP updates bitmap
+ * PF/VF sends this message to negotiate PTP capabilities. CP updates bitmap
  * with supported features and fulfills appropriate structures.
+ * If Devcie Control recommends primary MBX for PTP: secondary_mbx is set to false.
+ * If Device control recommends secondary MBX for PTP: secondary_mbx is set to true.
+ * Control plane has 2 MBX and the driver has 1 or 2 MBX, send_to_peer_driver
+ * opcode must be be used to send a message when ptp_peer_mb_q_id is valid using 
+ * ptp_peer_mb_q_id and ptp_peer_id.
+ * If the Device does not require send_to peer_driver opcode: peer_mbx_q_id holds
+ * invalid value (0xFFFF) and the driver can simply use send_to_pf opcode.
  *
- * Associated with VIRTCHNL2_OP_GET_PTP_CAPS.
+ * Associated with VIRTCHNL2_OP_PTP_GET_CAPS.
  */
-struct virtchnl2_get_ptp_caps {
-	__le32 ptp_caps;
+struct virtchnl2_ptp_get_caps {
+	__le32 caps;
+	__le32 max_adj;
+	__le64 base_incval;
+	__le16 peer_mbx_q_id;
+	u8 peer_id;
+	u8 secondary_mbx;
 	u8 pad[4];
 
-	struct virtchnl2_ptp_legacy_cross_time_reg legacy_cross_time_reg;
-	struct virtchnl2_ptp_ptm_cross_time_reg ptm_cross_time_reg;
-	struct virtchnl2_ptp_device_clock_control device_clock_control;
-	struct virtchnl2_ptp_tx_tstamp tx_tstamp;
+	struct virtchnl2_ptp_clk_reg_offsets clk_offsets;
+	struct virtchnl2_ptp_cross_time_reg_offsets cross_time_offsets;
+	struct virtchnl2_ptp_clk_adj_reg_offsets clk_adj_offsets;
 };
-VIRTCHNL2_CHECK_STRUCT_VAR_LEN(88, virtchnl2_get_ptp_caps,
-			       tx_tstamp.ptp_tx_tstamp_entries);
 
-/**
- * struct virtchnl2_ptp_tx_tstamp_latch - Structure that describes tx tstamp
+VIRTCHNL2_CHECK_STRUCT_LEN(104, virtchnl2_ptp_get_caps);
+
+/* struct virtchnl2_ptp_tx_tstamp_latch - Structure that describes tx tstamp
  *					  values, index and validity.
- * @tstamp_h: Timestamp high
- * @tstamp_l: Timestamp low
+ * @tstamp: Timestamp value
  * @index: Index
  * @valid: Timestamp validity
- * @pad: Padding
+ * @pad: Padding for future extensions
  */
 struct virtchnl2_ptp_tx_tstamp_latch {
-	__le32 tstamp_h;
-	__le32 tstamp_l;
+	__le64 tstamp;
 	u8 index;
 	u8 valid;
 	u8 pad[6];
 };
+
 VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_tx_tstamp_latch);
 
 /**
- * struct virtchnl2_ptp_tx_tstamp_latches - PTP TX timestamp latches
+ * struct virtchnl2_ptp_get_vport_tx_tstamp_latches - Tx timestamp latches
+ *						      associated with the vport
+ * @vport_id: Number of vport that requests the timestamp
  * @num_latches: Number of latches
- * @latch_size: Latch size expressed in bits
- * @pad: Padding
+ * @get_devtime_with_txtstmp: Flag to request device time along with Tx timestamp
+ * @pad: Padding for future extensions
+ * @device_time: device time if get_devtime_with_txtstmp was set in request
  * @tstamp_latches: PTP TX timestamp latch
  *
  * PF/VF sends this message to receive a specified number of timestamps
  * entries.
  *
- * Associated with VIRTCHNL2_OP_GET_PTP_TX_TSTAMP_LATCHES.
+ * Associated with VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP.
  */
-struct virtchnl2_ptp_tx_tstamp_latches {
+struct virtchnl2_ptp_get_vport_tx_tstamp_latches {
+	__le32 vport_id;
 	__le16 num_latches;
-	__le16 latch_size;
-	u8 pad[4];
+	u8 get_devtime_with_txtstmp;
+	u8 pad[1];
+	u64 device_time;
+
 	struct virtchnl2_ptp_tx_tstamp_latch tstamp_latches[STRUCT_VAR_LEN];
 };
-VIRTCHNL2_CHECK_STRUCT_VAR_LEN(24, virtchnl2_ptp_tx_tstamp_latches,
+
+VIRTCHNL2_CHECK_STRUCT_VAR_LEN(24, virtchnl2_ptp_get_vport_tx_tstamp_latches,
 			       tstamp_latches);
+
+/* VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME
+ * @dev_time_ns: Device clock time value in nanoseconds
+ * @pad: Padding for future extensions
+ *
+ * PF/VF sends this message to receive the time from the main timer
+ */
+struct virtchnl2_ptp_get_dev_clk_time {
+	__le64 dev_time_ns;
+	u8 pad[8];
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_get_dev_clk_time);
+
+/* VIRTCHNL2_OP_PTP_GET_CROSS_TIME
+ * @sys_time_ns: System counter value expressed in nanoseconds, read
+ *		 synchronously with device time
+ * @dev_time_ns: Device clock time value expressed in nanoseconds
+ * @pad: Padding for future extensions
+ *
+ * PF/VF sends this message to receive the cross time
+ */
+struct virtchnl2_ptp_get_cross_time {
+	__le64 sys_time_ns;
+	__le64 dev_time_ns;
+	u8 pad[8];
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(24, virtchnl2_ptp_get_cross_time);
+
+/* VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME
+ * @dev_time_ns: Device time value expressed in nanoseconds to set
+ * @pad: Padding for future extensions
+ *
+ * PF/VF sends this message to set the time of the main timer
+ */
+struct virtchnl2_ptp_set_dev_clk_time {
+	__le64 dev_time_ns;
+	u8 pad[8];
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_ptp_set_dev_clk_time);
+
+/* VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE
+ * @incval: Source timer increment value per clock cycle
+ *
+ * PF/VF sends this message to adjust the frequency of the main timer by the
+ * indicated scaled ppm.
+ */
+struct virtchnl2_ptp_adj_dev_clk_fine {
+	__le64 incval;
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_ptp_adj_dev_clk_fine);
+
+/* VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME
+ * @delta: Offset in nanoseconds to adjust the time by
+ *
+ * PF/VF sends this message to adjust the time of the main timer by the delta
+ */
+struct virtchnl2_ptp_adj_dev_clk_time {
+	__le64 delta;
+};
+
+VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_ptp_adj_dev_clk_time);
 
 static inline const char *virtchnl2_op_str(__le32 v_opcode)
 {
@@ -10311,10 +10527,24 @@ static inline const char *virtchnl2_op_str(__le32 v_opcode)
 	case VIRTCHNL2_OP_GET_EDT_CAPS:
 		return "VIRTCHNL2_OP_GET_EDT_CAPS";
 #endif /* VIRTCHNL2_EDT_SUPPORT */
-	case VIRTCHNL2_OP_GET_PTP_CAPS:
-		return "VIRTCHNL2_OP_GET_PTP_CAPS";
-	case VIRTCHNL2_OP_GET_PTP_TX_TSTAMP_LATCHES:
-		return "VIRTCHNL2_OP_GET_PTP_TX_TSTAMP_LATCHES";
+	case VIRTCHNL2_OP_PTP_GET_CAPS:
+		return "VIRTCHNL2_OP_PTP_GET_CAPS";
+	case VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP:
+		return "VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP";
+	case VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME:
+		return "VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME";
+	case VIRTCHNL2_OP_PTP_GET_CROSS_TIME:
+		return "VIRTCHNL2_OP_PTP_GET_CROSS_TIME";
+	case VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME:
+		return "VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME";
+	case VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE:
+		return "VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE";
+	case VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME:
+		return "VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME";
+	case VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS:
+		return "VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS";
+	case VIRTCHNL2_OP_GET_LAN_MEMORY_REGIONS:
+		return "VIRTCHNL2_OP_GET_LAN_MEMORY_REGIONS";
 #ifdef NOT_FOR_UPSTREAM
 	case VIRTCHNL2_OP_GET_OEM_CAPS:
 		return "VIRTCHNL2_OP_GET_OEM_CAPS";
@@ -10622,30 +10852,58 @@ virtchnl2_vc_validate_vf_msg(struct virtchnl2_version_info *ver, u32 v_opcode,
 			err_msg_format = true;
 		break;
 #endif /* VIRTCHNL2_IWARP */
-	case VIRTCHNL2_OP_GET_PTP_CAPS:
-		num_chunks = ((struct virtchnl2_get_ptp_caps *)msg)->tx_tstamp.num_latches;
-		valid_len = struct_size_t(struct virtchnl2_get_ptp_caps,
-					  tx_tstamp.ptp_tx_tstamp_entries,
-					  num_chunks);
-		if (!is_flex_array)
-			valid_len -= sizeof(struct virtchnl2_ptp_tx_tstamp_entry);
-
-		/* Zero entries is allowed as input */
-		if (!num_chunks && msglen > valid_len)
-			valid_len += sizeof(struct virtchnl2_ptp_tx_tstamp_entry);
-
+	case VIRTCHNL2_OP_PTP_GET_CAPS:
+		valid_len = sizeof(struct virtchnl2_ptp_get_caps);
 		break;
-	case VIRTCHNL2_OP_GET_PTP_TX_TSTAMP_LATCHES:
-		num_chunks = ((struct virtchnl2_ptp_tx_tstamp_latches *)msg)->num_latches;
+	case VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP:
+		num_chunks = ((struct virtchnl2_ptp_get_vport_tx_tstamp_latches *)msg)->num_latches;
 		if (!num_chunks) {
 			err_msg_format = true;
 			break;
 		}
 
-		valid_len = struct_size_t(struct virtchnl2_ptp_tx_tstamp_latches,
+		valid_len = struct_size_t(struct virtchnl2_ptp_get_vport_tx_tstamp_latches,
 					  tstamp_latches, num_chunks);
 		if (!is_flex_array)
 			valid_len -= sizeof(struct virtchnl2_ptp_tx_tstamp_latch);
+
+		break;
+	case VIRTCHNL2_OP_PTP_GET_DEV_CLK_TIME:
+		valid_len = sizeof(struct virtchnl2_ptp_get_dev_clk_time);
+		break;
+	case VIRTCHNL2_OP_PTP_GET_CROSS_TIME:
+		valid_len = sizeof(struct virtchnl2_ptp_get_cross_time);
+		break;
+	case VIRTCHNL2_OP_PTP_SET_DEV_CLK_TIME:
+		valid_len = sizeof(struct virtchnl2_ptp_set_dev_clk_time);
+		break;
+	case VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_FINE:
+		valid_len = sizeof(struct virtchnl2_ptp_adj_dev_clk_fine);
+		break;
+	case VIRTCHNL2_OP_PTP_ADJ_DEV_CLK_TIME:
+		valid_len = sizeof(struct virtchnl2_ptp_adj_dev_clk_time);
+		break;
+	case VIRTCHNL2_OP_PTP_GET_VPORT_TX_TSTAMP_CAPS:
+		num_chunks = ((struct virtchnl2_ptp_get_vport_tx_tstamp_caps *)msg)->num_latches;
+
+		valid_len = struct_size_t(struct virtchnl2_ptp_get_vport_tx_tstamp_caps,
+					  tstamp_latches, num_chunks);
+
+		if (!is_flex_array)
+			valid_len -= sizeof(struct virtchnl2_ptp_tx_tstamp_latch_caps);
+
+		break;
+	case VIRTCHNL2_OP_GET_LAN_MEMORY_REGIONS:
+		num_chunks = ((struct virtchnl2_get_lan_memory_regions *)msg)->num_memory_regions;
+		if (!num_chunks) {
+			err_msg_format = true;
+			break;
+		}
+
+		valid_len = struct_size_t(struct virtchnl2_get_lan_memory_regions,
+					  mem_reg, num_chunks);
+		if (!is_flex_array)
+			valid_len -= sizeof(struct virtchnl2_mem_region);
 
 		break;
 	/* These are always errors coming from the VF */

--- a/idpf_specification.md
+++ b/idpf_specification.md
@@ -11626,25 +11626,26 @@ struct idc_rdma_vport_auxiliary_drv {
  
  - Capability and Data structures
 
-  The response from <span class="mark">VIRTCHNL2_OP_GET_CAPS will have the</span> VIRTCHNL2_DEVICE_TYPE, oem_cp_major_version, and oem_cp_minor_version to indicate what device and the CP SW the driver is talking to.
+  The response from <span class="mark">VIRTCHNL2_OP_GET_CAPS will have the</span> device_type, cp_major_version, and cp_minor_version to indicate what device and the CP SW the driver is talking to.
   
+  Vendor can define their own data structures for negotiating capabilities keeping in mind sizing of the struct to ease forward/backward compatibility etc., keeping field members naturally aligned and explicitly adding padding where necessary.
+
   Driver will use the VIRTCHNL2_OP_GET_OEM_CAPS message to learn about the special capabilities that are available. A suggested data structure that goes along with this opcode and example capability and flow could look like below
 
 ```C
   struct virtchnl2_oem_caps {
-    /* See VIRTCHNL2_OEM_CAPS definitions */
-    /* Add 64 bit OEM_version here */
+      /* Add 64 bit OEM_version here */
     __le64 oem_caps;
   };
 
-  #define VIRTCHNL2_CAP_OEM_P2P BIT(0) /* port-to-port */
+  #define VIRTCHNL2_CAP_OEM_PUSHQ BIT(0) /* Push Queue */
   ```
 
 - Configuration
 
 - Driver Configuration and Runtime flow Examples of OEM Capability:
-  1.  Port-to-port configuration
-  **port-to-port:** Upon learning the port-to-port availability and the device type, the driver may request Control plane to add device specific sequence that may request additional resources that are necessary for the device to setup the port-to-port functionality.
+  1.  Push Queue configuration
+  **Push_Queue:** Upon learning the port-to-port availability and the device type, the driver may request Control plane to add device specific sequence that may request additional resources that are necessary for the device to setup the Push queue functionality.
   
 
 - Device and Control Plane Behavioral Model

--- a/idpf_specification.md
+++ b/idpf_specification.md
@@ -6456,47 +6456,21 @@ a standard capability to a PF or a VF device
   
   On driver initialization/load if the PTP capability is supported by device, driver will register the PTP object along with two read callbacks. *Gettime64* for reading the device clock and *Getcrosststamp* for PTM(Precision Time Measurement). The device registers to read the device clock are SHTIME, SHTIME_L and SHTIME_H. ART_L and ART_H are used for PTM.
 
-## OEM Capabilities (WIP)
+## OEM Capabilities
 
-This spec allows the OEMs to add new capabilities and export them to the IDPF compatible driver.
+This spec allows the OEMs to add new OEM specific capabilities and export them to an IDPF compatible vendor driver.
 
 - Device Interface
   
-  The driver learns and negotiates the OEM specific capabilities from the device. Based on the current device and the node policy, certain capabilities will be made available to the driver.
+  The driver learns and negotiates the OEM specific capabilities from the device. Based on the current device type as sepcified in get_capabilities and device policy, certain capabilities will be made available to the driver.
 
 - Capability and Data structures
 
   The response from <span class="mark">VIRTCHNL2_OP_GET_CAPS will have the</span> VIRTCHNL2_DEVICE_TYPE, oem_cp_major_version, and oem_cp_minor_version to indicate what device and the CP SW the driver is talking to.
   
-  Driver will use the VIRTCHNL2_OP_GET_OEM_CAPS message to learn about the special capabilities that are available.
+  Driver will use the VIRTCHNL2_OP_GET_OEM_CAPS message to learn about the special capabilities that are available. A suggested OEM capability negotiation struct and details plus examples can be found in the Spec appendix.
 
-  ```C
-  struct virtchnl2_oem_caps {
-    /* See VIRTCHNL2_OEM_CAPS definitions */
-    /* Add 64 bit OEM_version here */
-    __le64 oem_caps;
-  };
-
-  #define VIRTCHNL2_CAP_OEM_P2P BIT(0) /* port-to-port */
-  ```
-
-- Configuration
-
-- Driver Configuration and Runtime flow Examples of OEM Capability:
-  1.  Port-to-port configuration
-  **port-to-port:** Upon learning the port-to-port availability and the device type, the driver may request HMA to add device specific sequence that may request additional queue groups that are necessary for the device to setup the port-to-port functionality.
-  2.  Live MIgration, device state retrieval (WIP)
-
-- Device and Control Plane Behavioral Model
-
-- Examples of OEM Capability:
-  1.  port-to-port:
-  
-    The VIRTCHNL2_OP_ADD_QUEUE_GROUPS processing on the CP will automatically reserve enough RSS LUT instances for the incoming packets to be spread across the port-to-port queues. When the port-to-port offload is no longer needed, the driver may free up the associated NIC resources using the VIRTCHNL2_OP_DEL_QUEUE_GROUPS command.
-  
-  2.  Live MIgration, device state state retrieval (WIP)
-
-## Application Targeted Routing (ATR)
+  ## Application Targeted Routing (ATR)
 
 - Device Interface
 
@@ -8297,7 +8271,7 @@ enum virtchnl2_op {
 
 	/* All OEM specific opcodes start at higher offset. This will allow
 	 * OEMs to use the virtchannel header with old opcodes and their own
-	 * specific opcodes. Every OEM is reserved 1000 opcodes. All opcodes and
+	 * specific opcodes. All opcodes and
 	 * structure names of a specific OEM must include OEM specific
 	 * identifier. For example the identifier in the below case is OEM_1.
 	 */
@@ -8899,12 +8873,8 @@ VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_version_info);
  *			    linearized.
  * @reserved: Reserved field
  * @max_adis: Max number of ADIs
-#ifdef NOT_FOR_UPSTREAM
- * @oem_cp_ver_major: OEM CP major version number
- * @oem_cp_ver_minor: OEM CP minor version number
-#else
- * @reserved1: Reserved field
-#endif
+ * @oem_cp_ver_major: CP major version number
+ * @oem_cp_ver_minor: CP minor version number
  * @device_type: See enum virtchl2_device_type
  * @min_sso_packet_len: Min packet length supported by device for single
  *			segment offload
@@ -8966,12 +8936,8 @@ struct virtchnl2_get_capabilities {
 	u8 max_sg_bufs_per_tx_pkt;
 	u8 reserved;
 	__le16 max_adis;
-#ifdef NOT_FOR_UPSTREAM
 	__le16 oem_cp_ver_major;
 	__le16 oem_cp_ver_minor;
-#else
-	u8 reserved1[4];
-#endif /* NOT_FOR_UPSTREAM */
 	__le32 device_type;
 	u8 min_sso_packet_len;
 	u8 max_hdr_buf_per_lso;
@@ -11654,3 +11620,38 @@ struct idc_rdma_vport_auxiliary_drv {
 };
 #endif /* _IDC_RDMA_H_*/
 ```
+
+# Appendix : OEM Capabilities
+ Vendor can define their own OEM specific capabilities and develop a vendor driver that is IDPF compliant.
+ 
+ - Capability and Data structures
+
+  The response from <span class="mark">VIRTCHNL2_OP_GET_CAPS will have the</span> VIRTCHNL2_DEVICE_TYPE, oem_cp_major_version, and oem_cp_minor_version to indicate what device and the CP SW the driver is talking to.
+  
+  Driver will use the VIRTCHNL2_OP_GET_OEM_CAPS message to learn about the special capabilities that are available. A suggested data structure that goes along with this opcode and example capability and flow could look like below
+
+```C
+  struct virtchnl2_oem_caps {
+    /* See VIRTCHNL2_OEM_CAPS definitions */
+    /* Add 64 bit OEM_version here */
+    __le64 oem_caps;
+  };
+
+  #define VIRTCHNL2_CAP_OEM_P2P BIT(0) /* port-to-port */
+  ```
+
+- Configuration
+
+- Driver Configuration and Runtime flow Examples of OEM Capability:
+  1.  Port-to-port configuration
+  **port-to-port:** Upon learning the port-to-port availability and the device type, the driver may request Control plane to add device specific sequence that may request additional resources that are necessary for the device to setup the port-to-port functionality.
+  
+
+- Device and Control Plane Behavioral Model
+
+- Examples of OEM Capability:
+  1.  port-to-port:
+  
+    The VIRTCHNL2_OP_P2P_REQUEST_RESOURCES can be an opcode defined above opcode 5000. This opcode processing on the CP will reserve enough resources for the incoming packets to be spread across the port-to-port queues. When the port-to-port offload is no longer needed, the driver may free up the associated NIC resources using the VIRTCHNL2_OP_P2P_RELEASE_RESOURCES command.
+  
+  


### PR DESCRIPTION
 Main Feature Completed:
    PTP Offload capability support definition as this
    was earlier work in progress.

 Minor Fix from previous additions:
    Also added some minor header file missed opcode
    and data structes for learning about LAN
    memory_regions as was introduced during the
    RDMA capability support.
