### PR TITLE
Cleanup devicetype

### DIFF
--- a/how
+++ b/how
@@ -1,0 +1,892 @@
+[33mcommit 9dce2ca64522cd2cdc96524ac37c438f8fc31486[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mcleanup_devicetype[m[33m, [m[1;32mmain[m[33m)[m
+Author: anjalisinghai1 <anjali.singhai@intel.com>
+Date:   Thu Apr 10 17:54:00 2025 -0700
+
+    Merge branch 'main' of https://github.com/oasis-tcs/idpf-specification
+
+[33mcommit 2942bc73b0b4392dd7830513ca817acffbcb9f4f[m[33m ([m[1;31morigin/main[m[33m, [m[1;31morigin/HEAD[m[33m)[m
+Merge: 7e2a028 ae8257a
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Wed Apr 9 16:02:55 2025 -0700
+
+    Merge pull request #41 from kkazatsk/kirill_pdf_update
+    
+    Re-generated .pdf file with black font
+
+[33mcommit 7e2a0282ed123426ca0ef409c867cd16bce8ac4a[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Fri Jan 10 21:09:26 2025 -0600
+
+    Update PTP usage of secondary dedicated mailbox (#45)
+    
+    Clarify the usage of secondary dedicated mailbox in the PTP offload
+    section of the spec and update the virtchnl2 header file.
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+
+[33mcommit ae8257a5b8a59695721f2dde4e5589948e057e27[m
+Author: kirill <kirill.kazatsker@intel.com>
+Date:   Thu Nov 28 13:42:51 2024 +0200
+
+    Re-generated .pdf with updated Queue and Vport state machine
+
+[33mcommit 89b767940686bdc3cef596bab54802e909189258[m
+Merge: f0880a2 8bf0dae
+Author: kkazatsk <94841815+kkazatsk@users.noreply.github.com>
+Date:   Thu Nov 28 13:40:35 2024 +0200
+
+    Merge branch 'oasis-tcs:main' into kirill_pdf_update
+
+[33mcommit 8bf0dae8e1247c480bd88ac6392ab50627544e73[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Wed Nov 27 12:28:55 2024 -0600
+
+    Cleanup VIRTCHNL2_CAP_XXX capabilities that are not supported. (#44)
+    
+    Cleanup some capabilities that are not negotiated and expected to be supported by default.
+
+[33mcommit 3ec8c2fc3f5763c46025638a241fd001a2ed6d4a[m
+Author: kkazatsk <94841815+kkazatsk@users.noreply.github.com>
+Date:   Wed Nov 27 17:48:31 2024 +0200
+
+    Updated Pictures of Vport and Queue Management state machines (#42)
+    
+    * Updated Pictures of Vport and Queue Management state machines
+    
+    * Update Vport FSM drawing
+
+[33mcommit f0880a2e97eab234e1ba545cb63d8af1fe5a8514[m
+Merge: 3c504df 8c8303a
+Author: kkazatsk <94841815+kkazatsk@users.noreply.github.com>
+Date:   Mon Nov 25 15:43:44 2024 +0200
+
+    Merge branch 'oasis-tcs:main' into kirill_pdf_update
+
+[33mcommit 8c8303a5afc318fbf10f24f123172ae078a0b713[m
+Author: Joe Jordan <joseph.jordan@intel.com>
+Date:   Thu Nov 14 11:28:08 2024 -0800
+
+    Revert "Review IDPF file"
+
+[33mcommit 0f669a8df6a409534e8ecbc189d42f934aec6a38[m
+Merge: 7b8c5c2 67e810f
+Author: Joe Jordan <joseph.jordan@intel.com>
+Date:   Thu Nov 14 11:24:36 2024 -0800
+
+    Merge pull request #26 from oasis-tcs/review-idpf-spec-branch
+    
+    Review IDPF file
+
+[33mcommit 7b8c5c2ada69821a41d56a439c184117a8a53971[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Fri Nov 8 16:22:04 2024 -0800
+
+    Cleanup Flow Steering Section
+
+[33mcommit 8df0f0f1b3ca8d8447781222d7be010800608848[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Wed Oct 23 12:26:59 2024 -0700
+
+    Update default RX buffer size minimum limits
+
+[33mcommit 67e810fe6ed95ee9ef537ed5023fa7bdcd6feb2b[m[33m ([m[1;31morigin/review-idpf-spec-branch[m[33m)[m
+Merge: 25064a7 c982dbf
+Author: Jordan, Joseph <joseph.jordan@intel.com>
+Date:   Wed Nov 13 15:09:19 2024 -0800
+
+    trying again to resolve conflicts
+
+[33mcommit 25064a7b917390691c3899d880f6f6edbc363bf6[m
+Author: Jordan, Joseph <joseph.jordan@intel.com>
+Date:   Wed Nov 13 15:06:56 2024 -0800
+
+    remaining files from the rebase
+
+[33mcommit 3e12addbdba1737fc24fd3d5cba7e6c6ae81027e[m
+Author: Jordan, Joseph <joseph.jordan@intel.com>
+Date:   Wed Nov 13 15:06:01 2024 -0800
+
+    rebasing, resolving conflicts and a few minor edits
+
+[33mcommit 3c504dfddd95b2a008954b36a902852271d4fced[m
+Author: kirill <kirill.kazatsker@intel.com>
+Date:   Mon Nov 11 13:29:02 2024 +0200
+
+    Re-generated .pdf file with black font
+
+[33mcommit 887937ed6afa8d5c0bbca7781baa508dce043ab0[m
+Merge: ea6aa1a 865c9ff
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Tue Nov 5 10:50:31 2024 -0800
+
+    Merge pull request #40 from oasis-tcs/anjalisinghai1-patch-2
+    
+    Create Kirill's IDPF branch and readme.txt
+
+[33mcommit 865c9ffcdce1422209915cbf0aa195f64a6e60ee[m[33m ([m[1;31morigin/anjalisinghai1-patch-2[m[33m)[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Tue Nov 5 10:49:31 2024 -0800
+
+    Create Kirill's IDPF branch and readme.txt
+
+[33mcommit c982dbfd0a749ed103c82d67cf1bfd8c260c0461[m
+Merge: f79c100 a75d4ca
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Thu Oct 17 16:41:49 2024 -0700
+
+    Merge pull request #38 from dandaly/main
+    
+    IDPF 1.0 PDF Version
+
+[33mcommit a75d4caaac191b7f584a702c63c9a766ba6a810d[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Thu Oct 17 16:16:33 2024 -0700
+
+    IDPF 1.0 PDF Version
+    
+    Signed-off-by: Dan Daly <dandaly@pobox.com>
+
+[33mcommit f79c10081ce522d8a560ec3f9a2d88d59757d4fb[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Thu Oct 17 11:53:30 2024 -0700
+
+    Spec Version update to 1.0 (#37)
+    
+    * Clean up of WIP sections and marking them
+    appropriately
+    
+    * Virtchannel header files are up to date.
+    
+    * Flow Steering offload details.
+    
+    * Some formatting fixes
+    
+    * Some more formatting fixes.
+    
+    * Some more format fix.
+    
+    * reset flow updates.
+    
+    * Final reset flow cleanup.
+    
+    * Spec version update to 1.0 as per the Ballot
+    Results.
+
+[33mcommit 7de3cc2a6cc4c0a9286628554194d4371b4f28b3[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Thu Oct 17 11:46:25 2024 -0700
+
+    Reset flow updates (#36)
+    
+    * Clean up of WIP sections and marking them
+    appropriately
+    
+    * Virtchannel header files are up to date.
+    
+    * Flow Steering offload details.
+    
+    * Some formatting fixes
+    
+    * Some more formatting fixes.
+    
+    * Some more format fix.
+    
+    * reset flow updates.
+    
+    * Final reset flow cleanup.
+
+[33mcommit 33e47853e3b244672a3aa4811af6629e098358d5[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Wed Oct 16 13:26:07 2024 -0700
+
+    Add flow steering flow offload details (#35)
+    
+    * Clean up of WIP sections and marking them
+    appropriately
+    
+    * Virtchannel header files are up to date.
+    
+    * Flow Steering offload details.
+    
+    * Some formatting fixes
+    
+    * Some more formatting fixes.
+    
+    * Some more format fix.
+
+[33mcommit 40639ae57613baf2272f34935db568206689a9ad[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Wed Oct 16 10:03:31 2024 -0700
+
+    Cleanup of WIP items (#33)
+    
+    * Clean up of WIP sections and marking them
+    appropriately
+    
+    * Virtchannel header files are up to date.
+
+[33mcommit ea6aa1a5d6c6628a0ebac3e7f0dcf332d08ec7ef[m
+Author: Bo Zhang <bo.b.zhang@intel.com>
+Date:   Sun Oct 13 22:39:26 2024 -0700
+
+    Update idpf_specification.md
+    
+    Reviewed lines 179-637 “Virtchannel and Mailbox Queue” and majority of "RX Queues"
+
+[33mcommit 448283d17c81e81e8b07c07821806e8d0f997ab8[m
+Author: Bo Zhang <bo.b.zhang@intel.com>
+Date:   Sun Oct 13 20:11:16 2024 -0700
+
+    Update idpf_specification.md
+    
+    Reviewed lines 70-76 related to virtchannel
+
+[33mcommit 66057f56d290564c3e27f16cd6ddadb8adc7eef4[m
+Author: Bo Zhang <bo.b.zhang@intel.com>
+Date:   Sun Oct 13 19:53:17 2024 -0700
+
+    Update idpf_specification.md
+    
+    reviewed lines 1-35
+
+[33mcommit 911969c4e81eb2a33c34a3879f312315362adf34[m
+Merge: 6c537e9 8999889
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Sun Oct 13 19:25:46 2024 -0500
+
+    Merge pull request #32 from sharoncornelius/patch-11
+    
+    Update idpf_specification.md (remove space and comma)
+
+[33mcommit 8999889a53c0c40ea8b10022037a74905580b865[m
+Merge: c004b91 6c537e9
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Sun Oct 13 19:25:33 2024 -0500
+
+    Merge branch 'main' into patch-11
+
+[33mcommit 6c537e9efddde9256a27ee6f4342b606612fe938[m
+Merge: 53407e0 3f9e4ac
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Thu Oct 10 22:59:53 2024 -0500
+
+    Merge pull request #31 from sharoncornelius/patch-10
+    
+    Update idpf_specification.md (updates retry)
+
+[33mcommit 53407e0a0cf920791eb2824124c32586955a978d[m
+Merge: f9f049d 8e993c0
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Thu Oct 10 22:57:17 2024 -0500
+
+    Merge pull request #30 from sharoncornelius/patch-9
+    
+    Update idpf_specification.md (added new table)
+
+[33mcommit c004b91ef613db69389af4723d5f4e13e6136efb[m
+Author: sharoncornelius <69830914+sharoncornelius@users.noreply.github.com>
+Date:   Fri Oct 11 11:39:39 2024 +0800
+
+    Update idpf_specification.md
+
+[33mcommit 3f9e4ac27665786febb9ad1873097cc06ef0baef[m
+Author: sharoncornelius <69830914+sharoncornelius@users.noreply.github.com>
+Date:   Fri Oct 11 10:57:12 2024 +0800
+
+    Update idpf_specification.md (updates retry)
+
+[33mcommit 8e993c0688bc9cdafb8f8cf0fefce261fea021e6[m
+Author: sharoncornelius <69830914+sharoncornelius@users.noreply.github.com>
+Date:   Fri Oct 11 10:15:10 2024 +0800
+
+    Update idpf_specification.md (added new table)
+
+[33mcommit f9f049d9e19eae1b12c667545c41e40ad5d61ad5[m
+Merge: 281bc88 5712624
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Thu Oct 10 16:40:10 2024 -0500
+
+    Merge pull request #29 from ssamudrala/main
+    
+    EDT updates
+
+[33mcommit 571262458276a84f8610903981e22ba6081461d1[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Thu Oct 10 11:29:27 2024 -0700
+
+    EDT updates
+    
+    Update EDT offload section
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+
+[33mcommit 281bc885e87701707b1483f13f32e9af773c5aa9[m
+Merge: 11c5ed1 eb7cd70
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Mon Oct 7 22:11:18 2024 -0500
+
+    Merge pull request #28 from ssamudrala/main
+    
+    Replace IECM references with IDPF
+
+[33mcommit 78f2796bbed2cc085ae05acb0a4519c99b55be7c[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Mon Oct 7 17:10:35 2024 -0700
+
+    Update idpf_specification.md
+    
+    Please use this PR to put in your comments.
+
+[33mcommit 6223a336be7d79a17d3f2ff62d19bdf99c551db5[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Mon Oct 7 16:53:48 2024 -0700
+
+    Delete FILE_FOR_REVIEW-PR_idpf_specification.md
+    
+    Accidental Add.
+
+[33mcommit eb7cd70352e961b1dd1cdf78a162a23ad77f4f32[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Mon Oct 7 15:21:57 2024 -0700
+
+    Replace IECM references with IDPF
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+
+[33mcommit 11c5ed1f80bc83b8dcb782a92e4500ae329fffc3[m
+Merge: 501a492 d23027b
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Fri Oct 4 11:19:54 2024 -0500
+
+    Merge pull request #27 from ssamudrala/main
+    
+    Add device level capability to negotiate tstamp granularity in tx com…
+
+[33mcommit d23027bc8f95218a906d3d99924b7ec07d2fa0ec[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Thu Oct 3 19:41:34 2024 -0700
+
+    Add device level capability to negotiate tstamp granularity in tx compl descriptor
+
+[33mcommit 46c9ca9005ce455ad36499f1a54486415a138c7a[m
+Author: Jordan, Joseph <joseph.jordan@intel.com>
+Date:   Thu Sep 26 12:24:18 2024 -0700
+
+    created a new file for reviewers to use when looking at the PR
+
+[33mcommit 501a492333df8ee48351a0c1f7559b1a652c8925[m
+Merge: d501765 24ec26a
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Wed Sep 25 14:28:35 2024 -0500
+
+    Merge pull request #25 from mapenner/patch-1
+    
+    Rename tx_tso_context_desc-dtype0x05.png to tx_tso_context_desc_dtype…
+
+[33mcommit 24ec26ac366c09219dd5d6903881428ef8dbc596[m
+Author: mapenner <michael.a.penner@intel.com>
+Date:   Fri Sep 20 10:01:42 2024 -0700
+
+    Rename tx_tso_context_desc-dtype0x08.png to tx_tso_context_desc_dtype0x08.png
+    
+    Renamed to align with reference in the spec and naming convention used for all images ('_' instead of '-')
+
+[33mcommit 1b0bc76d0a48e55f35fa1513444864c6aabc681a[m
+Author: mapenner <michael.a.penner@intel.com>
+Date:   Fri Sep 20 10:00:05 2024 -0700
+
+    Rename tx_tso_context_desc-dtype0x05.png to tx_tso_context_desc_dtype0x05.png
+    
+    Renamed to align with the reference in the spec and naming convention used for other images ('_' instead of '-').
+
+[33mcommit d501765cf1af3d835e568f7b9d428b422651fa62[m
+Merge: e36fb81 8eba982
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Tue Sep 10 15:35:44 2024 -0500
+
+    Merge pull request #24 from sharoncornelius/patch-8
+    
+    Update idpf_specification.md (Header Updates 2)
+
+[33mcommit 8eba982201d960421fc8a52517e377289799e071[m
+Author: sharoncornelius <69830914+sharoncornelius@users.noreply.github.com>
+Date:   Tue Sep 10 17:40:52 2024 +0800
+
+    Update idpf_specification.md (Header Updates 2)
+
+[33mcommit e36fb81adb7c79b5623dc91012fa8ab2d0ea4f4e[m
+Author: Sridhar Samudrala <sridhar.samudrala@intel.com>
+Date:   Wed Sep 4 18:50:23 2024 -0500
+
+    idpf spec updates (#21)
+    
+    * Add idpf_lan_txrx.h header file: TX and TX Completion descpriptors
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+    
+    * update virtchnl2.h
+    
+    add flow steering support
+    add missing lan memory region structures
+    some code indentation fixes
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+    
+    * Update device capabilities and resource limits section
+    
+    Document device capabilities, resource limits and associated SW
+    parameters used to store the default or negotiated values.
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+    
+    ---------
+    
+    Signed-off-by: Sridhar Samudrala <sridhar.samudrala@intel.com>
+
+[33mcommit 54f43fa9002fe8dfa265812aa44fd19a5ff31771[m
+Author: sharoncornelius <69830914+sharoncornelius@users.noreply.github.com>
+Date:   Thu Sep 5 07:49:20 2024 +0800
+
+    Test edit Note sytle (#19)
+
+[33mcommit 216e0907bffe0c66450b4a9ba7e9829a7d4f2802[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Mon Jun 3 17:05:54 2024 -0700
+
+    Remove an accidental commit of an additional file. (#20)
+    
+    Signed-off-by: anjalisinghai1 <singhai.anjali55@gmail.com>
+
+[33mcommit 11173c47a5aec347f7145b4ace9b6ae6b7edc245[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Thu May 30 19:13:56 2024 -0700
+
+    Main Feature Completed: PTP Offload capability support definition  (#18)
+    
+    * Main Feature Completed: PTP Offload capability support definition as this was earlier work in progress.
+    All the review comments were addressed/fixed.
+    
+    Minor Fix from previous additions:
+    Also added some minor header file missed opcode and data structures for learning about LAN memory_regions as was introduced during the RDMA capability support.
+
+[33mcommit d3a466f432dbc41af8c26fa6bf85f7da5dd85787[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Sun Apr 28 20:16:11 2024 -0700
+
+    Clean up the OEM Capabilities section  (#16)
+    
+    * Clean up the OEM Capabilities section as that is to support vendor specific features in a vendor driver.
+    
+    Moved the details as suggested examples into Appendix instead
+    of in the main Spec as the Spec does not impose a fixed format or flow
+    for the OEM capabilities.
+    
+    * Review comments merged.
+
+[33mcommit b05c9df5cd33a78d438087845862b94c1081657d[m[33m ([m[1;32mptp1[m[33m, [m[1;32mhelp[m[33m)[m
+Author: Anjali Singhai Jain <anjali.singhai@intel.com>
+Date:   Thu Mar 14 07:27:32 2024 -0700
+
+    RDMA Capability support details (#14)
+    
+    * RDMA Capability support details
+    
+    * Review feedback fixup for original RDMA PR.
+    
+    * Added the teardown flow detail in the RDMA appendix section.
+
+[33mcommit a74f1d30933a45e90f59a483dabe6b9d0f8af398[m
+Merge: 8f3c8c0 b08b19e
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Tue Mar 5 17:15:24 2024 -0800
+
+    Merge pull request #13 from oasis-tcs/cleanup-2
+    
+    Added the PCI Programming Interface details for IDPF
+
+[33mcommit b08b19e9d2aa1b6ed9590901507d7284f30d6ac2[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Tue Mar 5 17:05:37 2024 -0800
+
+    Added the PCI Programming Interface details for
+    IDPF
+
+[33mcommit 8f3c8c0db32d7b35fd3839249773354672efa598[m
+Merge: 5c57c28 893f3a1
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Mon Mar 4 14:55:31 2024 -0800
+
+    Merge pull request #12 from oasis-tcs/cleanup-2
+    
+    Update the header files in Appendix with new datastructures and capabilities
+
+[33mcommit 893f3a13eae57678bf088a511d6c9ddfc5d95f92[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Mon Mar 4 14:52:04 2024 -0800
+
+    Update the header files in Appendix with new
+    datastructures and capabilities.
+
+[33mcommit 5c57c282a81762f724e90b465b2d163bfe06f2cb[m
+Merge: ad216f1 2f1e539
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Sun Mar 3 20:56:11 2024 -0800
+
+    Merge pull request #11 from oasis-tcs/cleanup-2
+    
+    Cleanup 2
+
+[33mcommit 2f1e5399a49bb215411c1a42c9ba12434aa8172f[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Sun Mar 3 20:48:44 2024 -0800
+
+    Some more Code formatting fixes.
+
+[33mcommit 803fdd342d153e9c6a4a04d860cf69490c4c0b06[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Sun Mar 3 19:41:52 2024 -0800
+
+    Formatted code sections, added some more
+    clarifications for Register offsets.
+    Also replaced use of the tern HW with Device where
+    appropriate. Fixed heading indentation etc.
+
+[33mcommit 874371f90975180428add12a080b153700db3c5c[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Fri Mar 1 16:53:21 2024 -0800
+
+    First set of cleanup till Section Overall flows.
+
+[33mcommit ad216f1203db8710394a1cff6cfeb9843db28886[m
+Merge: 469dd5a dc98add
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri Mar 1 15:56:34 2024 -0800
+
+    Merge pull request #9 from oasis-tcs/diagram-set2
+    
+    Diagram Set 2
+
+[33mcommit dc98add8c89c995d6fe0b92798e0f60469e0313e[m[33m ([m[1;31morigin/diagram-set2[m[33m, [m[1;32mdiagram-set2[m[33m)[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Fri Mar 1 15:50:30 2024 -0800
+
+    Add the remaining diagrams. Also remove one from
+    PTP section as it needs to be updated.
+
+[33mcommit aa4a87f598341d767242060934ed9ad6be222365[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Fri Mar 1 15:42:02 2024 -0800
+
+    Add second and final set of images. Also remove
+    an image from PTP section as it needs to be updated.
+
+[33mcommit 469dd5a205651c48ce58e332651f27ed432cb008[m
+Merge: 56d9695 83e483f
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri Mar 1 13:32:51 2024 -0800
+
+    Merge pull request #8 from oasis-tcs/diagram-set1
+    
+    Include missing set of Diagrams. Set 1
+
+[33mcommit 83e483fdf9331c703dcb26cb65bae51b9073d13d[m[33m ([m[1;31morigin/diagram-set1[m[33m, [m[1;32mdiagram-set1[m[33m)[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Thu Feb 29 17:48:54 2024 -0800
+
+    Include missings et of Diagrams. Set 1
+
+[33mcommit 56d969538e0b9852a98ea57bf6cb5ccd576bc729[m[33m ([m[1;32manjali[m[33m)[m
+Merge: ec50775 8699d06
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Thu Feb 29 17:33:32 2024 -0800
+
+    Merge pull request #6 from oasis-tcs/anjalisinghai1-patch-1
+    
+    Diagrams set 1
+
+[33mcommit 8699d06c230f59e5199a0a19bc31499fd57dd868[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Thu Feb 29 17:32:52 2024 -0800
+
+    Diagrams set 1
+
+[33mcommit ec50775331e94dafd87e5f91e7a5d29a04845f25[m
+Merge: 6658d16 a961d3d
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Tue Feb 20 17:07:35 2024 -0800
+
+    Merge pull request #5 from oasis-tcs/cleanup
+    
+    Cleanup parts taht should not be in the Spec
+
+[33mcommit a961d3d5d992f6b9182021f11a23f4b475aa4b06[m[33m ([m[1;31morigin/cleanup[m[33m, [m[1;32mcleanup[m[33m)[m
+Author: anjalisinghai1 <singhai.anjali55@gmail.com>
+Date:   Tue Feb 20 17:04:55 2024 -0800
+
+    Cleanup parts taht should not be in the Spec
+
+[33mcommit 6658d166bb17d4bf0fe594bb41943889ffca4424[m[33m ([m[1;32manajli[m[33m)[m
+Merge: cc2294b 50a0a14
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Tue Feb 20 16:18:18 2024 -0800
+
+    Merge pull request #4 from oasis-tcs/OASIS-OP-Admin-patch-2
+    
+    Fix SRIOV to SR-IOV
+
+[33mcommit 50a0a14e189bff3c43e30b413d99849febfc919c[m[33m ([m[1;31morigin/OASIS-OP-Admin-patch-2[m[33m, [m[1;32mOASIS-OP-Admin-patch-2[m[33m)[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Wed Feb 21 00:14:02 2024 +0000
+
+    Fix SRIOV to SR-IOV
+
+[33mcommit cc2294bf0ce081c61a79ffa862e3fbbafbd657ef[m
+Merge: b95fa4e 98b2aba
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Mon Feb 19 20:54:42 2024 -0800
+
+    Merge pull request #3 from oasis-tcs/OASIS-OP-Admin-patch-2
+    
+    Initial Spec 0.91
+
+[33mcommit 98b2aba6fbe79023aa5b2891c207d538cccc93e9[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Mon May 15 10:06:34 2023 -0700
+
+    Fixed L3L4P copy/paste translation issue
+
+[33mcommit cf141ce2729b49b8e56eb056ae830600805553d1[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Mon May 15 09:25:49 2023 -0700
+
+    Fixed typo in giant list
+
+[33mcommit 0dcc7f39f647539dff5ffe5a12d270033df0726c[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Mon May 15 09:22:49 2023 -0700
+
+    Delete idpf.md
+
+[33mcommit 56956d334eb5b31117162097ba423ee07b13368b[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Mon May 15 09:20:28 2023 -0700
+
+    Reformatting the tail end of the spec
+
+[33mcommit 0aa9afc46487f4a5a1a20dc6a1cfe25056176625[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Mon May 15 09:12:02 2023 -0700
+
+    More formatting
+
+[33mcommit f3696fe96d15ef0559ce29516198cf75559c5088[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 23:05:42 2023 -0700
+
+    Third pandoc fix set
+
+[33mcommit 132aaff3e711a5b51fe0de91a147f3c5219963a8[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 22:57:18 2023 -0700
+
+    Second batch of pandoc edits
+
+[33mcommit e1708195f041796783d74f399cae67c78e29d6d1[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 22:32:51 2023 -0700
+
+    Second round of formatting
+
+[33mcommit 5ca956665d8af0dc23693968dd1646eb2ee1f596[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 22:23:55 2023 -0700
+
+    FIrst set of formatting fixes from pandoc import
+
+[33mcommit 1aee9f728258e01aa5150694e4be97867ff09820[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 21:56:25 2023 -0700
+
+    Added the remaining from pandoc
+
+[33mcommit c8122af6ea0bd5aa293724e9cb193204ef5a8daf[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 21:46:34 2023 -0700
+
+    Temporary version of idpf
+
+[33mcommit c48d068512157980db89b33f4e9e643dc5bdca2b[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Sat May 13 00:17:19 2023 -0700
+
+    chunk 6
+
+[33mcommit cbb430fbdfdad546fb749769b641fe672de475ca[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 23:57:46 2023 -0700
+
+    5th chunk
+
+[33mcommit 0260f3d2e3cfdd66e0959c1e6346fbe5918c9f3f[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri May 12 17:06:29 2023 -0700
+
+    Device Receive descriptors diagram
+
+[33mcommit 5f625597f79180e1e86d4d7703e6ed496dab99b8[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri May 12 16:59:46 2023 -0700
+
+    descriptor ring layout
+
+[33mcommit 76c759a630680d32a4201ad994734c3f370ad485[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri May 12 16:50:20 2023 -0700
+
+    marked code in c format
+
+[33mcommit cd90333127fb8b599ee75f1d621dc4b30ddfddac[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 16:03:42 2023 -0700
+
+    Update idpf_specification.md fifth section
+
+[33mcommit 8600ddf0ba933b61ad8a58ffb588c2a6e8a5ede7[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:34:58 2023 -0700
+
+    Update idpf_specification.md fourth chunk
+
+[33mcommit f1f314a0231797eb1fe8853e3c4d36b7f1076ee0[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:32:05 2023 -0700
+
+    Update idpf_specification.md alignment issues
+
+[33mcommit d5275167f655c3c163caac11ecf8001666bb3f53[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:26:06 2023 -0700
+
+    Update idpf_specification.md more formatting
+
+[33mcommit ee272a6aa82b20c34fbe8e62361271373b6a8b40[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:20:30 2023 -0700
+
+    Update idpf_specification.md formatting
+
+[33mcommit 626736baefa6bdc5ca0919b780fcd91ae67e455a[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:17:41 2023 -0700
+
+    Add files via upload
+
+[33mcommit 89a8ae33f5f3fff4c17c297342b9e5f1caf054f7[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 15:15:29 2023 -0700
+
+    Update idpf_specification.md third section
+
+[33mcommit 03c53f3a966965e8994f0f4cf1fa85f5699d110a[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 14:56:34 2023 -0700
+
+    Update idpf_specification.md first image reference
+
+[33mcommit 6d99652bce1d5914524a6b4429a1f6a962d4d8fc[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 14:55:43 2023 -0700
+
+    Add files via upload
+
+[33mcommit fde399eec5c26ea29739d21ee679d80b44a3368e[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 14:28:00 2023 -0700
+
+    Update idpf_specification.md second section
+
+[33mcommit c02b59958696931e7eb6d28455f040cfe70b0b24[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 14:17:39 2023 -0700
+
+    Create idpf_specification.md
+
+[33mcommit 6c5f6a03c818de54b450917128937ed730737b4a[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri May 12 10:36:39 2023 -0700
+
+    IDPF_Device_1
+
+[33mcommit 5a68b747a5943973f6f9dcbd781bad1542f7f7e7[m
+Author: Anjali Singhai Jain <singhai.anjali55@gmail.com>
+Date:   Fri May 12 10:27:10 2023 -0700
+
+    Create readme for Diagrams
+
+[33mcommit 3a803aa2159f34d609ce2788c523253d466f4f86[m
+Author: Dan Daly <dandaly@pobox.com>
+Date:   Fri May 12 09:02:53 2023 -0700
+
+    Create CODEOWNERS
+
+[33mcommit b95fa4ebc7e72878fc07f37e45c0ebc86ea632ec[m
+Merge: a1e9417 03360f3
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:39:31 2023 -0400
+
+    Merge pull request #2 from oasis-tcs/OASIS-OP-Admin-patch-2
+    
+    Update README.md
+
+[33mcommit 03360f3126d2204b2b784ab7499b13c2484a9fa3[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:39:22 2023 -0400
+
+    Update README.md
+    
+    Fixing error in the description of a TC Github repo
+
+[33mcommit a1e94177894b815c974a3c42fb3deeaf89e79531[m
+Merge: 2e50e2f 89ee2b5
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:37:07 2023 -0400
+
+    Merge pull request #1 from oasis-tcs/OASIS-OP-Admin-patch-1
+    
+    Update README.md
+
+[33mcommit 89ee2b5419146c5ab31a4725d45824842a0b90f1[m[33m ([m[1;31morigin/OASIS-OP-Admin-patch-1[m[33m, [m[1;32mOASIS-OP-Admin-patch-1[m[33m)[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:36:53 2023 -0400
+
+    Update README.md
+
+[33mcommit 2e50e2fa7438d4cffa7170c98325d64123857348[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:10:39 2023 -0400
+
+    Create CONTRIBUTING.md
+
+[33mcommit c64a8d7406d295b03901242c4a0984c10b6a4f70[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:05:20 2023 -0400
+
+    fix LICENSE.MD to LICENSE.md
+
+[33mcommit 73e6f96db5f33bec1dbb761ea0c1d5311480dad3[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 15:01:51 2023 -0400
+
+    Create LICENSE.MD
+
+[33mcommit 4cc1f5ebeddb5eb62718c6b59aef62fd519c87b3[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 14:58:59 2023 -0400
+
+    add README.md
+
+[33mcommit 4bf481b9d21da0d85322c888105bc459525c0c8d[m
+Author: OASIS-OP-Admin <47402065+OASIS-OP-Admin@users.noreply.github.com>
+Date:   Mon Jun 12 11:39:49 2023 -0400
+
+    Initial commit

--- a/idpf_specification.md
+++ b/idpf_specification.md
@@ -8536,11 +8536,8 @@ enum virtchnl2_op {
 	VIRTCHNL2_OP_FLOW_RULE_IDS_GET			        = 554,
 	VIRTCHNL2_OP_FLOW_RULE_BY_IDS_DEL		        = 555,
 
-#ifdef NOT_FOR_UPSTREAM
-	VIRTCHNL2_OP_GET_OEM_CAPS		                = 4999,
-#endif /* NOT_FOR_UPSTREAM */
 #ifndef EXTERNAL_RELEASE
-
+	VIRTCHNL2_OP_GET_OEM_CAPS		                = 4999,
 	/* All OEM specific opcodes start at higher offset. This will allow
 	 * OEMs to use the virtchannel header with old opcodes and their own
 	 * specific opcodes. All opcodes and
@@ -8746,29 +8743,12 @@ enum virtchnl2_flow_types {
 	VIRTCHNL2_FLOW_IPV6_AH_ESP	= BIT(13),
 };
 
-#ifdef NOT_FOR_UPSTREAM
-/**
- * VIRTCHNL2_OEM_CAPS
- * OEM capability flags
- * The chipset is detected at runtime, and the capability flags will be
- * selected according to this identification.
- */
-#define VIRTCHNL2_CAP_OEM_P2P			BIT(0)
-/* Other OEM specific caps */
-
 /* Underlying device type */
 enum virtchl2_device_type {
-	VIRTCHNL2_MEV_DEVICE			= 0,
-	VIRTCHNL2_MEV_TS_DEVICE			= 1,
+	VIRTCHNL2_UNSPECIFIED			= 0,
+	/* Value 1 - 4 are allocated to existing devices */
+    /* All other Device Type values are avaiable for allocation */
 };
-
-#endif /* NOT_FOR_UPSTREAM */
-#ifndef EXTERNAL_RELEASE
-/**
- * HLV CP/HMA returns device type as 0
- * INTEL CP/HMA returns device type as 1
- */
-#endif
 
 /**
  * enum virtchnl2_txq_sched_mode - Transmit Queue Scheduling Modes
@@ -8868,12 +8848,6 @@ enum virtchnl2_event_codes {
  * @VIRTCHNL2_QUEUE_TYPE_RX_BUFFER: RX buffer queue type
  * @VIRTCHNL2_QUEUE_TYPE_CONFIG_TX: Config TX queue type
  * @VIRTCHNL2_QUEUE_TYPE_CONFIG_RX: Config RX queue type
-#ifdef NOT_FOR_UPSTREAM
- * @VIRTCHNL2_QUEUE_TYPE_P2P_TX: P2P TX queue type
- * @VIRTCHNL2_QUEUE_TYPE_P2P_RX: P2P RX queue type
- * @VIRTCHNL2_QUEUE_TYPE_P2P_TX_COMPLETION: P2P TX completion queue type
- * @VIRTCHNL2_QUEUE_TYPE_P2P_RX_BUFFER: P2P RX buffer queue type
-#endif
  * @VIRTCHNL2_QUEUE_TYPE_MBX_TX: TX mailbox queue type
  * @VIRTCHNL2_QUEUE_TYPE_MBX_RX: RX mailbox queue type
  *
@@ -8889,14 +8863,7 @@ enum virtchnl2_queue_type {
 	VIRTCHNL2_QUEUE_TYPE_RX_BUFFER		= 3,
 	VIRTCHNL2_QUEUE_TYPE_CONFIG_TX		= 4,
 	VIRTCHNL2_QUEUE_TYPE_CONFIG_RX		= 5,
-#ifdef NOT_FOR_UPSTREAM
-	VIRTCHNL2_QUEUE_TYPE_P2P_TX		= 6,
-	VIRTCHNL2_QUEUE_TYPE_P2P_RX		= 7,
-	VIRTCHNL2_QUEUE_TYPE_P2P_TX_COMPLETION	= 8,
-	VIRTCHNL2_QUEUE_TYPE_P2P_RX_BUFFER	= 9,
-#else
 	/* Queue types 6, 7, 8, 9 are reserved */
-#endif /* NOT_FOR_UPSTREAM */
 	VIRTCHNL2_QUEUE_TYPE_MBX_TX		= 10,
 	VIRTCHNL2_QUEUE_TYPE_MBX_RX		= 11,
 };
@@ -8967,11 +8934,6 @@ enum virtchnl2_queue_group_type {
 	VIRTCHNL2_QUEUE_GROUP_MBX		= 2,
 	VIRTCHNL2_QUEUE_GROUP_CONFIG		= 3,
 };
-
-#ifdef NOT_FOR_UPSTREAM
-/* 0x100 and on is for OEM */
-#define VIRTCHNL2_QUEUE_GROUP_P2P		0x100
-#endif /* NOT_FOR_UPSTREAM */
 
 /* Protocol header type within a packet segment. A segment consists of one or
  * more protocol headers that make up a logical group of protocol headers. Each
@@ -9085,17 +9047,6 @@ struct virtchnl2_edt_caps {
 VIRTCHNL2_CHECK_STRUCT_LEN(16, virtchnl2_edt_caps);
 #endif /* VIRTCHNL2_EDT_SUPPORT */
 
-#ifdef NOT_FOR_UPSTREAM
-/**
- * struct virtchnl2_oem_caps - Get OEM capabilities
- * @oem_caps: See VIRTCHNL2_OEM_CAPS definitions
- */
-struct virtchnl2_oem_caps {
-	__le64 oem_caps;
-};
-VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_oem_caps);
-#endif /* NOT_FOR_UPSTREAM */
-
 /**
  * struct virtchnl2_version_info - Version information
  * @major: Major version
@@ -9147,7 +9098,7 @@ VIRTCHNL2_CHECK_STRUCT_LEN(8, virtchnl2_version_info);
  * @max_adis: Max number of ADIs
  * @oem_cp_ver_major: CP major version number
  * @oem_cp_ver_minor: CP minor version number
- * @device_type: See enum virtchl2_device_type
+ * @device_type: A magic number used to indetify the Network device for debug only; should never be used for any logic check in the standard driver
  * @min_sso_packet_len: Min packet length supported by device for single
  *			segment offload
  * @max_hdr_buf_per_lso: Max number of header buffers that can be used for
@@ -9265,18 +9216,13 @@ VIRTCHNL2_CHECK_STRUCT_VAR_LEN(40, virtchnl2_queue_reg_chunks, chunks);
  * @VIRTCHNL2_VPORT_INLINE_FLOW_STEER_RXQ: Inline flow steering enabled
  * with explicit Rx queue action
  * @VIRTCHNL2_VPORT_SIDEBAND_FLOW_STEER: Sideband flow steering enabled
-#ifdef NOT_FOR_UPSTREAM
- * @VIRTCHNL2_VPORT_PORT2PORT_PORT: Port2port port flag
-#endif
  */
 enum virtchnl2_vport_flags {
 	VIRTCHNL2_VPORT_UPLINK_PORT		= BIT(0),
 	VIRTCHNL2_VPORT_INLINE_FLOW_STEER	= BIT(1),
 	VIRTCHNL2_VPORT_INLINE_FLOW_STEER_RXQ	= BIT(2),
 	VIRTCHNL2_VPORT_SIDEBAND_FLOW_STEER	= BIT(3),
-#ifdef NOT_FOR_UPSTREAM
-	VIRTCHNL2_VPORT_PORT2PORT_PORT		= BIT(15),
-#endif /* NOT_FOR_UPSTREAM */
+	/* BIT(4) is reserved */
 };
 
 #ifndef LINUX_SUPPORT
@@ -11046,10 +10992,6 @@ static inline const char *virtchnl2_op_str(__le32 v_opcode)
 		return "VIRTCHNL2_OP_FLOW_RULE_IDS_GET";
 	case VIRTCHNL2_OP_FLOW_RULE_CHECK:
 		return "VIRTCHNL2_OP_FLOW_RULE_CHECK";
-#ifdef NOT_FOR_UPSTREAM
-	case VIRTCHNL2_OP_GET_OEM_CAPS:
-		return "VIRTCHNL2_OP_GET_OEM_CAPS";
-#endif /* NOT_FOR_UPSTREAM */
 	default:
 		return "Unsupported (update virtchnl2.h)";
 	}
@@ -11336,11 +11278,6 @@ virtchnl2_vc_validate_vf_msg(struct virtchnl2_version_info *ver, u32 v_opcode,
 		valid_len = sizeof(struct virtchnl2_edt_caps);
 		break;
 #endif /* VIRTCHNL2_EDT_SUPPORT */
-#ifdef NOT_FOR_UPSTREAM
-	case VIRTCHNL2_OP_GET_OEM_CAPS:
-		valid_len = sizeof(struct virtchnl2_oem_caps);
-		break;
-#endif /* NOT_FOR_UPSTREAM */
 #ifdef VIRTCHNL2_IWARP
 	case VIRTCHNL2_OP_RDMA:
 		/* These messages are opaque to us and will be validated in
@@ -12721,7 +12658,7 @@ struct idc_rdma_vport_auxiliary_drv {
 
 - Driver Configuration and Runtime flow Examples of OEM Capability:
   1.  Push Queue configuration
-  **Push_Queue:** Upon learning the port-to-port availability and the device type, the driver may request Control plane to add device specific sequence that may request additional resources that are necessary for the device to setup the Push queue functionality.
+  **Push_Queue:** Upon learning the push queue availability and the device type, the driver may request Control plane to add device specific sequence that may request additional resources that are necessary for the device to setup the Push queue functionality.
   
 
 - Device and Control Plane Behavioral Model


### PR DESCRIPTION
General Cleanup

1. Device Type definition and allocation updated.
2. OEM capability related details removed from the header file as they belong only in a vendor driver and OEM/vendor can choose to define it based on what the device is capable of.